### PR TITLE
BDF fonts may not contain bitmaps for all glyphs

### DIFF
--- a/sfdnormalize/__main__.py
+++ b/sfdnormalize/__main__.py
@@ -226,7 +226,7 @@ def process_sfd_file(sfdname, outname):
                 out.write(fl);
             elif in_chars and curglyph != '':
                 glyphs[curglyph]['lines'].append(fl)
-            elif in_bdf:
+            elif in_bdf and cur_gid in bdf:
                 bdf[cur_gid]['lines'].append(fl)
 
         fl = fp.readline()


### PR DESCRIPTION
In that case, the glyph is assumed blank.

Example SFD: https://github.com/ctrlcctrlv/clR8x8/blob/6ad37df11ba7588318bfdd2b93e3779a4a76cf55/SchumacherClean-Regular.sfd