### PR TITLE
fixed case of invalid iterable

### DIFF
--- a/sfdnormalize/__main__.py
+++ b/sfdnormalize/__main__.py
@@ -105,9 +105,10 @@ def process_sfd_file(args):
 
     fl = fp.readline()
     while fl:
-        if proc.test(DROP_RE, fl) and not any([fl.startswith(k) for k in args.keep]):
-            fl = fp.readline()
-            continue
+        if proc.test(DROP_RE, fl):
+            if args.keep == None or not any([fl.startswith(k) for k in args.keep]):
+                fl = fp.readline()
+                continue
 
         elif in_chars:
             # Cleanup glyph flags


### PR DESCRIPTION
Fixed a bug on line 108: if the first part of the condition is true, the second part is evaluated. Then, if no `--keep` argument is supplied, `arg.keep = None`. Throws an error that `None` is not iterable. This is fixed by checking for `None` first.

In my case, this bug occurs when I edit a SFD file with FontForge, which creates a `ModificationTime` entry. This entry triggers the error, because it is contained in the to-drop list.